### PR TITLE
chore: configure enketo using environment variables

### DIFF
--- a/deploy/charts/odk-central/templates/odk-enketo/enketo_deployment.yaml
+++ b/deploy/charts/odk-central/templates/odk-enketo/enketo_deployment.yaml
@@ -57,7 +57,7 @@ spec:
       - name: {{ .Values.enketo.configSecretName }}
         configMap:
           name: {{ .Values.enketo.configSecretName }} 
-          defaultMode: 0700
+          defaultMode: 0777
       
       - name: enketo-secrets
         secret:

--- a/deploy/charts/odk-central/values.yaml
+++ b/deploy/charts/odk-central/values.yaml
@@ -42,8 +42,8 @@ enketo:
     port: 8005
   image:
     registry: docker.io
-    repository: openg2p/odk-central-enketo
-    tag: v2023.1.0
+    repository: enketo/enketo-express
+    tag: 6.2.0
     pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
This avoids us using `config/config.json` to add our configurations